### PR TITLE
Fix copy ratio bed offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,17 @@ Parameters to calculate coverage, filter out low quality intervals and call vari
 * a pair of _intervals.vcf (genotype of every interval in the input bed) and _segments.vcf (consecutive intervals with the same CNV status are merged) for each sample
 * gCNV.bed files for copy ratio visualisation in IGV.js for each sample
 * a gCNV.bed file of all samples on the run
-* list of intervals excluded from CNV calling for the run
+* list of intervals excluded from CNV calling for the run, both as a 0- and a 1-based BED file
+
+**How to run this app**:
+
+```bash
+dx run app-eggd_GATKgCNV_call/1.0.0 \
+  -iGATK_docker="<GATK_docker.tar.gz>" \
+  -iinterval_list="<output from prep app>" \
+  -iannotation_tsv="<output from prep app>" \
+  -ibambais="<array of paired sample bam and index file IDs>"
+```
 
 ## Dependencies
 The app requires a tar.gz of the Docker image for GATK 4.2+ as an input. Htslib and bedtools are bundled with the app.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Parameters to calculate coverage, filter out low quality intervals and call vari
 * a pair of _intervals.vcf (genotype of every interval in the input bed) and _segments.vcf (consecutive intervals with the same CNV status are merged) for each sample
 * gCNV.bed files for copy ratio visualisation in IGV.js for each sample
 * a gCNV.bed file of all samples on the run
-* list of intervals excluded from CNV calling for the run, both as a 0- and a 1-based BED file
+* list of intervals excluded from CNV calling for the run, a 0-based BED file
 
 **How to run this app**:
 

--- a/dxapp.json
+++ b/dxapp.json
@@ -3,7 +3,7 @@
     "title": "GATKgCNV_call",
     "summary": "GATK gCNV germline CNV caller",
     "dxapi": "1.0.0",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "inputSpec": [
         {
         "name": "GATK_docker",
@@ -32,6 +32,12 @@
         "class": "file",
         "optional": false,
         "patterns": ["*.interval_list"],
+        "suggestions": [
+            {
+            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+            "path": "/assets/GATK/gCNV_inputs/"
+            }
+        ],
         "help": "interval list sorted in chromosome order, created in the 'GATKgCNV_prep' step"
         },
         {
@@ -40,6 +46,12 @@
         "class": "file",
         "optional": false,
         "patterns": ["*.tsv"],
+        "suggestions": [
+            {
+            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+            "path": "/assets/GATK/gCNV_inputs/"
+            }
+        ],
         "help": "contains GC content, mappability and other annotation of target intervals"
         },
         {
@@ -55,7 +67,7 @@
         "class": "string",
         "optional": true,
         "default": "",
-        "help": "eg  '--format TSV'"
+        "help": "eg  '--format TSV', default is HDF5"
         },
         {
         "name": "FilterIntervals_args",

--- a/resources/home/dnanexus/generate_gcnv_bed.py
+++ b/resources/home/dnanexus/generate_gcnv_bed.py
@@ -93,6 +93,10 @@ def generate_copy_ratio_df(args):
         # add sample copy ratio to file
         copy_ratio_df[sample_name] = file_df[sample_name]
 
+    # Start coordinates are currently 1-based, need to be offset by 1
+    # to create a 0-based BED file for IGV visualisation
+    copy_ratio_df['start'] = copy_ratio_df['start'].apply(lambda x: x-1)
+
     return copy_ratio_df
 
 

--- a/src/GATK_gCNVcaller.sh
+++ b/src/GATK_gCNVcaller.sh
@@ -97,10 +97,21 @@ main() {
         -O /data/beds/filtered.interval_list
 
     echo "Identifying excluded intervals from CNV calling on this run"
-    grep -v "^@" inputs/beds/preprocessed.interval_list | bedtools sort > preprocessed.bed
-    grep -v "^@" inputs/beds/filtered.interval_list | bedtools sort > filtered.bed
-    bedtools intersect -v -a preprocessed.bed -b filtered.bed > excluded_intervals.bed
+    # Convert interval_list to BED files
+    docker run -v /home/dnanexus/inputs:/data $GATK_image gatk IntervalListToBed \
+        -I /data/beds/preprocessed.interval_list \
+        -O /data/beds/preprocessed.bed
+    docker run -v /home/dnanexus/inputs:/data $GATK_image gatk IntervalListToBed \
+        -I /data/beds/filtered.interval_list \
+        -O /data/beds/filtered.bed
 
+    # Identify regions that are in preprocessed but not in filtered, ie the excluded regions
+    bedtools intersect -v -a inputs/beds/preprocessed.bed -b inputs/beds/filtered.bed > excluded_intervals.bed
+
+    # Convert the 0-based bed file to 1-based
+    awk 'BEGIN {OFS="\t"}; {print $1,$2+1,$3}' excluded_intervals.bed > excluded_intervals_1based.bed
+
+    exit
     # 3. Run DetermineGermlineContigPloidy:
     # takes the base count tsv-s from the previous step, optional target_bed, and a contig plody priors tsv
     # outputs a ploidy model and ploidy-calls for each sample

--- a/src/GATK_gCNVcaller.sh
+++ b/src/GATK_gCNVcaller.sh
@@ -111,7 +111,6 @@ main() {
     # Convert the 0-based bed file to 1-based
     awk 'BEGIN {OFS="\t"}; {print $1,$2+1,$3}' excluded_intervals.bed > excluded_intervals_1based.bed
 
-    exit
     # 3. Run DetermineGermlineContigPloidy:
     # takes the base count tsv-s from the previous step, optional target_bed, and a contig plody priors tsv
     # outputs a ploidy model and ploidy-calls for each sample
@@ -194,6 +193,7 @@ main() {
     # and move result files into outdir to be uploaded
     mv inputs/vcfs/*.vcf ${vcf_dir}/
     mv excluded_intervals.bed ${summary_dir}/$run_name"_excluded_intervals.bed"
+    mv excluded_intervals_1based.bed ${summary_dir}/$run_name"_excluded_intervals_1based.bed"
 
     mark-section "Creating copy ratio visualisation files"
     # 7. Generate gcnv bed files from copy ratios for visualisation in IGV

--- a/src/GATK_gCNVcaller.sh
+++ b/src/GATK_gCNVcaller.sh
@@ -108,9 +108,6 @@ main() {
     # Identify regions that are in preprocessed but not in filtered, ie the excluded regions
     bedtools intersect -v -a inputs/beds/preprocessed.bed -b inputs/beds/filtered.bed > excluded_intervals.bed
 
-    # Convert the 0-based bed file to 1-based
-    awk 'BEGIN {OFS="\t"}; {print $1,$2+1,$3}' excluded_intervals.bed > excluded_intervals_1based.bed
-
     # 3. Run DetermineGermlineContigPloidy:
     # takes the base count tsv-s from the previous step, optional target_bed, and a contig plody priors tsv
     # outputs a ploidy model and ploidy-calls for each sample
@@ -193,7 +190,6 @@ main() {
     # and move result files into outdir to be uploaded
     mv inputs/vcfs/*.vcf ${vcf_dir}/
     mv excluded_intervals.bed ${summary_dir}/$run_name"_excluded_intervals.bed"
-    mv excluded_intervals_1based.bed ${summary_dir}/$run_name"_excluded_intervals_1based.bed"
 
     mark-section "Creating copy ratio visualisation files"
     # 7. Generate gcnv bed files from copy ratios for visualisation in IGV


### PR DESCRIPTION
After collecting copy ratio values across intervals for all samples, convert the 1-based start position to 0-based such that the resulting output file is a true 0-based and BED, ready for accurate display in IGV.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_gatkgcnv_call/7)
<!-- Reviewable:end -->
