### PR TITLE
fix typing of db (test cols removed)

### DIFF
--- a/resources/home/dnanexus/generate_gcnv_bed/generate_gcnv_bed.py
+++ b/resources/home/dnanexus/generate_gcnv_bed/generate_gcnv_bed.py
@@ -174,9 +174,6 @@ def read_all_copy_ratio_files(copy_ratio_files) -> pd.DataFrame:
                 "chr": "category",
                 "start": np.uint32,
                 "end": np.uint32,
-                "sample_1": float,
-                "sample_2": float,
-                "sample_3": float,
             }
         )
 


### PR DESCRIPTION
I left the test sample names in the astype() call but now they're gone

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_GATKgCNV_call/24)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated data type handling for sample columns in copy ratio DataFrame
	- Removed explicit float type specifications for sample columns

Note: These changes may impact data type consistency and should be reviewed carefully during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->